### PR TITLE
Multi plane transform

### DIFF
--- a/roibuddy/roi_buddy.py
+++ b/roibuddy/roi_buddy.py
@@ -1787,14 +1787,14 @@ class UI_tSeries(QListWidgetItem):
                 if any(transform_check):
                     wa.warn("Z-plane missing transform. Copying from adjacet" +
                             " plane, accuracy not guaranteed")
-                # If any planes were missing an anchor set, copy transforms
-                # from adjacent planes
-                for idx in range(len(transforms) - 1):
-                    if transforms[idx + 1] is None:
-                        transforms[idx + 1] = transforms[idx]
-                for idx in reversed(range(len(transforms) - 1)):
-                    if transforms[idx] is None:
-                        transforms[idx] = transforms[idx + 1]
+                    # If any planes were missing an anchor set, copy transforms
+                    # from adjacent planes
+                    for idx in range(len(transforms) - 1):
+                        if transforms[idx + 1] is None:
+                            transforms[idx + 1] = transforms[idx]
+                    for idx in reversed(range(len(transforms) - 1)):
+                        if transforms[idx] is None:
+                            transforms[idx] = transforms[idx + 1]
                 self.transforms[target_tSeries] = transforms
             else:
                 self.transforms[target_tSeries] = []


### PR DESCRIPTION
If you manually set registration anchors to align datasets for ROI imports, copy the transform between planes  instead of failing if you didn't manually align each frame.

Raise a warning if a transform is copied in this way.
