### PR TITLE
Issue 29 undo functionality

### DIFF
--- a/roibuddy/roi_buddy.py
+++ b/roibuddy/roi_buddy.py
@@ -278,6 +278,7 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
                                                self.add_tags_action,
                                                self.clear_tags_action,
                                                self.edit_tags_action,
+                                               self.update_roi_action,
                                                None,
                                                self.merge_rois,
                                                self.unmerge_rois,
@@ -342,6 +343,11 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
             self, "&Edit Tags", triggered=self.edit_tags,
             icon=QIcon(QString(os.path.join(icon_filepath, "edit.png"))),
             tip="Edit tags for the selected ROI")
+
+        self.update_roi_action = qthelpers.create_action(
+            self, "&Update", triggered=self.update_roi, shortcut="F11",
+            tip='Redraw the selected ROI with new ROI')
+        # self.addAction(self.update_roi)
 
         self.merge_rois = qthelpers.create_action(
             self, "&Merge", triggered=self.merge_ROIs, shortcut="M",
@@ -463,6 +469,11 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
         viewer.get_plot().get_items()[0].set_private(True)
         # add viewer to the display frame layout
         self.displayFrame.layout().addWidget(viewer)
+
+        # splitter = QSplitter(self)
+        # splitter.addWidget(viewer)
+        # self.displayFrame.layout().addWidget(splitter)
+        # self.displayFrame.setLayout(self.displayFrame.layout())
 
         # remove useless buttons
         for i in range(3, 18)[::-1]:
@@ -1067,6 +1078,33 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
                     poly.tags = split_tags
                     poly.update_name()
                     poly.update_color()
+
+    def update_roi(self):
+        """
+        Update the shape of an ROI with the shape of newly drawn ROI by
+        grabbing the shape of the new ROI drawn from the active drawing tool
+        """
+        if self.mode is 'edit':
+            # debug_trace()
+            new_points = self.viewer.active_tool.shape.get_points()
+            roi_to_update = self.plot.get_selected_items()
+            if len(roi_to_update) > 1:
+                QMessageBox.warning(
+                        self, 'Multiple Selected ROIs Error',
+                        'Please select one ROI to update',
+                        QMessageBox.Ok)
+                return
+            elif len(roi_to_update) == 0:
+                QMessageBox.warning(
+                    self, 'No ROI Selected Error',
+                    'Please select an ROI update',
+                    QMessageBox.Ok)
+                return
+            roi_to_update = roi_to_update[0]
+            roi_to_update.set_points(new_points)
+            self.viewer.active_tool.shape = None
+            self.plot.unselect_all()
+            self.plot.replot()
 
     def merge_ROIs(self):
         """

--- a/roibuddy/roi_buddy.py
+++ b/roibuddy/roi_buddy.py
@@ -345,7 +345,7 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
             tip="Edit tags for the selected ROI")
 
         self.update_roi_action = qthelpers.create_action(
-            self, "&Update", triggered=self.update_roi, shortcut="F11",
+            self, "&Update", triggered=self.update_roi, shortcut="B",
             tip='Redraw the selected ROI with new ROI')
         # self.addAction(self.update_roi)
 
@@ -1085,7 +1085,6 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
         grabbing the shape of the new ROI drawn from the active drawing tool
         """
         if self.mode is 'edit':
-            # debug_trace()
             new_points = self.viewer.active_tool.shape.get_points()
             roi_to_update = self.plot.get_selected_items()
             if len(roi_to_update) > 1:
@@ -1104,7 +1103,14 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
             roi_to_update.set_points(new_points)
             self.viewer.active_tool.shape = None
             self.plot.unselect_all()
+            items = self.plot.get_items()
+            items = filter(lambda obj: not isinstance(obj, ROI) and
+                           isinstance(obj, guiqwt.shapes.PolygonShape),
+                           items)
+            for item in items:
+                self.plot.del_item(item)
             self.plot.replot()
+            self.selection_tool.activate()
 
     def merge_ROIs(self):
         """

--- a/roibuddy/roi_buddy.py
+++ b/roibuddy/roi_buddy.py
@@ -189,17 +189,69 @@ class EllipseTool(RectangularShapeTool):
         super(EllipseTool, self).handle_final_shape(shape)
 
 
+class DeleteCmd(QUndoCommand):
+    """Instance of revertable delete command."""
+
+    def __init__(self, plot, mode, items_to_remove):
+        """Initialize the delete command."""
+        super(DeleteCmd, self).__init__()
+        self.plot = plot
+        self.mode = mode
+        self.items_to_remove = items_to_remove
+
+    def redo(self):
+        """Delete the selected items."""
+        self.plot.unselect_all()
+        if self.mode == 'align':
+            for item in self.items_to_remove:
+                item.parent.roi_list.remove(item)
+        self.plot.del_items(self.items_to_remove)
+        self.plot.replot()
+
+    def undo(self):
+        """Add the previously removed items back."""
+        if self.mode == 'align':
+            for item in self.items_to_remove:
+                item.parent.roi_list.append(item)
+        for item in self.items_to_remove:
+            self.plot.add_item(item)
+        self.plot.select_some_items(self.items_to_remove)
+        self.plot.replot()
+
+
+class UpdateROIShapeCmd(QUndoCommand):
+    """Instance of revertable ROI shape update command."""
+
+    def __init__(self, plot, roi_to_update, new_points):
+        """Initialize the update_roi command."""
+        super(UpdateROIShapeCmd, self).__init__()
+        self.plot = plot
+        self.roi_to_update = roi_to_update
+        self.new_points = new_points
+        self.old_points = self.roi_to_update.get_points()
+
+    def redo(self):
+        """Update the ROI object's points to the new values."""
+        self.roi_to_update.set_points(self.new_points)
+        self.plot.replot()
+
+    def undo(self):
+        """Revert the ROI object's points to the original values."""
+        self.roi_to_update.set_points(self.old_points)
+        self.plot.replot()
+
+
 class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
     """Instance of the ROI Buddy Qt interface."""
-    def __init__(self):
-        """
-        Initialize the application
-        """
 
+    def __init__(self):
+        """Initialize the application."""
         # initialize the UI and parent class
         QMainWindow.__init__(self)
         self.setupUi(self)
         self.setWindowTitle('ROI Buddy')
+
+        self.undoStack = QUndoStack(self)
 
         # define actions for menu bar and ROI manager
         self.define_actions()
@@ -296,6 +348,7 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
         self.plot.replot()
 
     def create_menu(self):
+        """Initialize the file menu."""
         self.file_menu = self.menuBar().addMenu("&File")
 
         qthelpers.add_actions(self.file_menu, [self.add_tseries_action,
@@ -310,16 +363,20 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
                                                self.edit_tags_action,
                                                self.update_roi_action,
                                                None,
+                                               self.undo_action,
+                                               self.redo_action,
+                                               None,
                                                self.merge_rois,
                                                self.unmerge_rois,
                                                None,
                                                self.quit_action])
 
     def create_status_bar(self):
+        """Initialize the status bar."""
         self.statusBar().addWidget(QLabel(""), 1)
 
     def define_actions(self):
-        # File menu actions
+        """File menu actions."""
         self.quit_action = qthelpers.create_action(
             self, "&Quit", triggered=self.close, shortcut="Ctrl+Q",
             tip="Close ROI Buddy")
@@ -336,7 +393,8 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
             self, "&Save current ROIs",
             triggered=lambda: self.save([self.tSeries_list.currentItem()]),
             shortcut="Ctrl+S",
-            icon=QIcon(os.path.join(icon_filepath,"document-save-5.png")),
+            icon=QIcon(os.path.join(icon_filepath,
+                                    "document-save-5.png")),
             tip="Save the current ROI set to file.")
 
         self.save_all_action = qthelpers.create_action(
@@ -377,7 +435,6 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
         self.update_roi_action = qthelpers.create_action(
             self, "&Update", triggered=self.update_roi, shortcut="B",
             tip='Redraw the selected ROI with new ROI')
-        # self.addAction(self.update_roi)
 
         self.merge_rois = qthelpers.create_action(
             self, "&Merge", triggered=self.merge_ROIs, shortcut="M",
@@ -416,11 +473,22 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
             shortcut='Ctrl+A')
         self.addAction(self.select_all_action)
 
+        self.undo_action = qthelpers.create_action(
+            self, "&Undo Action", triggered=self.undoStack.undo,
+            shortcut="Z", tip="Undo deletion of  an object.")
+        self.addAction(self.undo_action)
+
+        self.redo_action = qthelpers.create_action(
+            self, "&Redo Action", triggered=self.undoStack.redo,
+            shortcut="Y", tip="Redo deletion of an object.")
+        self.addAction(self.redo_action)
+
         self.debug_action = qthelpers.create_action(
             self, "&Debug", triggered=debug_trace, shortcut="F10")
         self.addAction(self.debug_action)
 
     def connectSignals(self):
+        """Connect events to their respective slots."""
 
         # toggle the edit or align mdoe
         self.modeSelection.buttonClicked.connect(self.toggle_mode)
@@ -660,12 +728,10 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
         items = self.plot.get_selected_items()
         # Don't delete the base image
         items = [item for item in items if not isinstance(item, ImageItem)]
-        self.plot.unselect_all()
-        if self.mode == 'align':
-            for item in items:
-                item.parent.roi_list.remove(item)
-        self.plot.del_items(items)
-        self.plot.replot()
+        cmd = DeleteCmd(self.plot,
+                        self.mode,
+                        items)
+        self.undoStack.push(cmd)
 
     def activate_freeform_tool(self):
         if self.mode == 'edit':
@@ -1110,8 +1176,10 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
 
     def update_roi(self):
         """
-        Update the shape of an ROI with the shape of newly drawn ROI by
-        grabbing the shape of the new ROI drawn from the active drawing tool
+        Update the shape of an ROI.
+
+        The ROI's shape is set to the the shape of newly drawn ROI by
+        the active drawing tool.
         """
         if self.mode is 'edit':
             new_points = self.viewer.active_tool.shape.get_points()
@@ -1129,7 +1197,9 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
                     QMessageBox.Ok)
                 return
             roi_to_update = roi_to_update[0]
-            roi_to_update.set_points(new_points)
+            cmd = UpdateROIShapeCmd(self.plot, roi_to_update,
+                                    new_points)
+            self.undoStack.push(cmd)
             self.plot.del_item(self.viewer.active_tool.shape)
             self.viewer.active_tool.reset()
             self.plot.unselect_all()

--- a/roibuddy/roi_buddy.py
+++ b/roibuddy/roi_buddy.py
@@ -790,7 +790,6 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
                                 and str(tag) in directory:
                             paths.append(join(root, directory))
 
-                paths.sort()
                 for p in paths:
                     UI_tSeries(p, parent=self)
 
@@ -1119,9 +1118,9 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
             roi_to_update = self.plot.get_selected_items()
             if len(roi_to_update) > 1:
                 QMessageBox.warning(
-                        self, 'Multiple Selected ROIs Error',
-                        'Please select one ROI to update',
-                        QMessageBox.Ok)
+                    self, 'Multiple Selected ROIs Error',
+                    'Please select one ROI to update',
+                    QMessageBox.Ok)
                 return
             elif len(roi_to_update) == 0:
                 QMessageBox.warning(
@@ -1131,14 +1130,9 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
                 return
             roi_to_update = roi_to_update[0]
             roi_to_update.set_points(new_points)
-            self.viewer.active_tool.shape = None
+            self.plot.del_item(self.viewer.active_tool.shape)
+            self.viewer.active_tool.reset()
             self.plot.unselect_all()
-            items = self.plot.get_items()
-            items = filter(lambda obj: not isinstance(obj, ROI) and
-                           isinstance(obj, guiqwt.shapes.PolygonShape),
-                           items)
-            for item in items:
-                self.plot.del_item(item)
             self.plot.replot()
             self.selection_tool.activate()
 


### PR DESCRIPTION
Canceling the deletion of an ROI was a feature missing from the ROI Buddy GUI. These changes handle both the undo calls and the redo calls for deleting an ROI object by adding the "delete an ROI" command to an undoStack. I've also added the ability to handle undo/redo calls for updating the shape of an ROI.  